### PR TITLE
Implement new device-global identifiers and routes capability

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -18,9 +18,9 @@
 #  else if any interface has been added, `c:r:a' becomes `c+1:0:a+1';
 #  else, `c:r:a' becomes `c:r+1:a'.
 #
-m4_define([comedilib_lt_current], [11])
-m4_define([comedilib_lt_revision], [1])
-m4_define([comedilib_lt_age], [11])
+m4_define([comedilib_lt_current], [12])
+m4_define([comedilib_lt_revision], [0])
+m4_define([comedilib_lt_age], [12])
 # Set 'letter', normally empty.  See below for rules.
 m4_define([comedilib_version_letter], [])
 

--- a/doc/comedilib.ent
+++ b/doc/comedilib.ent
@@ -1,2 +1,2 @@
 <!ENTITY comedi '<ulink url="http://www.comedi.org"><acronym>Comedi</acronym></ulink>'>
-<!ENTITY comedilib_version '0.11.1'>
+<!ENTITY comedilib_version '0.12.0'>

--- a/doc/comedilib.xml
+++ b/doc/comedilib.xml
@@ -43,6 +43,11 @@
 			<surname>Piel</surname>
 			<email>piel@delmic.com</email>
 		</author>
+		<author>
+			<firstname>Spencer</firstname>
+			<surname>Olson</surname>
+			<email>olsonse@umich.edu</email>
+		</author>
 		<copyright>
 			<year>1998-2003</year>
 			<holder>David Schleef</holder>
@@ -66,6 +71,10 @@
 		<copyright>
 			<year>2012, 2015</year>
 			<holder>Éric Piel</holder>
+		</copyright>
+		<copyright>
+			<year>2016-2018</year>
+			<holder>Spencer Olson</holder>
 		</copyright>
 
 		<abstract>

--- a/doc/extensions_funcref.txt
+++ b/doc/extensions_funcref.txt
@@ -42,6 +42,39 @@ Description:
 Returns:
  <literal>0</literal> on success, <literal>-1</literal> on error.
 
+Function: comedi_connect_route -- connect device-global route
+Retval: int
+Param: comedi_t * device
+Param: unsigned int source
+Param: unsigned int destination
+Status: alpha
+Description:
+ This function connects a globally-named route if such is connectible.
+ 
+ This operation is effectively the same as calling <function><link
+ linkend="func-ref-comedi-set-routing">comedi_set_routing</link></function> and
+ <function><link
+ linkend="func-ref-comedi-dio-config">comedi_dio_config</link></function> on the
+ appropriate subdevice.
+ 
+ There are several routes that are not globally connectable via <function><link
+ linkend="func-ref-comedi-connect-route">comedi_connect_route</link></function>,
+ such as (<code language="C">NI_PFI(i)</code> -->
+ <constant>NI_AO_SampleClock</constant>) as they must be connected via a trigger
+ argument, such as <code language="C">comedi_cmd->start_arg</code> for
+ <constant>NI_AO_StartTrigger</constant>.
+
+ The <parameter class="function">source</parameter> parameter specifies the
+ source of the signal route, whereas the <parameter
+ class="function">destination</parameter> parameter specifies the destination.
+ Possible values for source and destination are driver dependent but are
+ generally required to be values that are recognizable globally for a particular
+ device, independent of sub-device.
+Returns:
+ <literal>0</literal> on success, <literal>-1</literal> on error (and errno is
+ set appropriately--EALREADY: route is already connected; EINVAL: route invalid
+ for this device; EBUSY: destination selector used for another route).
+
 Function: comedi_digital_trigger_disable -- disable a digital trigger
 Retval: int
 Param: comedi_t * device
@@ -188,6 +221,38 @@ Description:
 Returns:
  <literal>0</literal> on success, <literal>-1</literal> on error.
 
+Function: comedi_disconnect_route -- disconnect device-global route
+Retval: int
+Param: comedi_t * device
+Param: unsigned int source
+Param: unsigned int destination
+Status: alpha
+Description:
+ This function disconnects a globally-named route if such is connected.
+ 
+ This operation is effectively the same as calling <function><link
+ linkend="func-ref-comedi-set-routing">comedi_set_routing</link></function> and
+ <function><link
+ linkend="func-ref-comedi-dio-config">comedi_dio_config</link></function> on the
+ appropriate subdevice.
+ 
+ There are several routes that are not globally dis-connectable via
+ <function><link
+ linkend="func-ref-comedi-connect-route">comedi_connect_route</link></function>,
+ such as (<code language="C">NI_PFI(i)</code> -->
+ <constant>NI_AO_SampleClock</constant>) as they must be connected via a trigger
+ argument, such as <code language="C">comedi_cmd->start_arg</code> for
+ <constant>NI_AO_StartTrigger</constant>.
+
+ The <parameter class="function">source</parameter> parameter specifies the
+ source of the signal route, whereas the <parameter
+ class="function">destination</parameter> parameter specifies the destination.
+ Possible values for source and destination are driver dependent but are
+ generally required to be values that are recognizable globally for a particular
+ device, independent of sub-device.
+Returns:
+ <literal>0</literal> on success, <literal>-1</literal> on error.
+
 Function: comedi_get_clock_source -- get master clock for a subdevice
 Retval: int
 Param: comedi_t * device
@@ -268,6 +333,49 @@ Description:
  an analog output).
 Returns:
  Hardware buffer size in bytes, or <literal>-1</literal> on error.
+
+Function: comedi_get_routes -- obtain list of all possible device-globally named routes
+Retval: int
+Param: comedi_t * device
+Param: comedi_route_pair * routelist
+Param: size_t n
+Status: alpha
+Description:
+ This function obtains a list of all possible globally-named routes for the
+ particular device.
+
+ A globally-named route is a route where the source and destination values are
+ globally recognized, regardless of the subdevice.
+ 
+ This function returns all possible signal routes that are either connectible
+ via <code language="C">comedi_cmd->start_arg</code> aruments or via the
+ device-global configuration interface of <function><link
+ linkend="func-ref-comedi-connect-route">comedi_connect_route</link></function>
+ and <function><link
+ linkend="func-ref-comedi-connect-route">comedi_disconnect_route</link></function>.
+
+ The <parameter class="function">routelist</parameter> parameter provides memory
+ into which the results may be copied.  The <code language="C">comedi_route_pair</code> is
+ (as specified in <emphasis>comedi.h</emphasis>):
+ <programlisting>
+    typedef struct {
+      unsigned int source;
+      unsigned int destination;
+    } comedi_route_pair;
+ </programlisting>
+
+ <parameter class="function">routelist</parameter> may be specified as
+ <constant>NULL</constant>, in which case only the number of routes will be
+ returned.
+
+ The <parameter class="function">n</parameter> parameter provides specifies the
+ number of slots available in the <parameter
+ class="function">routelist</parameter> array.
+Returns:
+ The number of routes available if <parameter
+ class="function">routelist</parameter> is <constant>NULL</constant>, the number
+ of routes copied if <parameter class="function">routelist</parameter> is not
+ <constant>NULL</constant>, or <literal>-1</literal> on error.
 
 Function: comedi_get_routing -- get routing for an output
 Retval: int
@@ -496,3 +604,45 @@ Description:
  configuration instruction.
 Returns:
  <literal>0</literal> on success, <literal>-1</literal> on error.
+
+Function: comedi_test_route -- validate and test device-global route
+Retval: int
+Param: comedi_t * device
+Param: unsigned int source
+Param: unsigned int destination
+Status: alpha
+Description:
+ This function validates a globally-named route as connectible and tests whether
+ the route is connected.
+ 
+ Note that since <function><link
+ linkend="func-ref-comedi-connect-route">comedi_connect_route</link></function>
+ and <function><link
+ linkend="func-ref-comedi-disconnect-route">comedi_disconnect_route</link></function>
+ effectively perform the same operations as <function><link
+ linkend="func-ref-comedi-set-routing">comedi_set_routing</link></function> /
+ <function><link
+ linkend="func-ref-comedi-get-routing">comedi_get_routing</link></function> and
+ <function><link
+ linkend="func-ref-comedi-dio-config">comedi_dio_config</link></function>, this
+ operation will only report a route as connected _if_ both operations have been
+ performed directly or effectively via comedi_connect_route.
+ 
+ There are several routes that are not globally connectable via <function><link
+ linkend="func-ref-comedi-connect-route">comedi_connect_route</link></function>,
+ such as (<code language="C">NI_PFI(i)</code> -->
+ <constant>NI_AO_SampleClock</constant>) as they must be connected via a trigger
+ argument, such as <code language="C">comedi_cmd->start_arg</code> for
+ <constant>NI_AO_StartTrigger</constant>.  This function can still be used for
+ such routes to test whether they are valid.
+
+ The <parameter class="function">source</parameter> parameter specifies the
+ source of the signal route, whereas the <parameter
+ class="function">destination</parameter> parameter specifies the destination.
+ Possible values for source and destination are driver dependent but are
+ generally required to be values that are recognizable globally for a particular
+ device, independent of sub-device.
+Returns:
+ <literal>-1</literal> if not connectible, <literal>0</literal> if connectible
+ but not connected, <literal>1</literal> if connectible <emphasis>and</emphasis>
+ connected.

--- a/doc/extensions_funcref.txt
+++ b/doc/extensions_funcref.txt
@@ -287,6 +287,48 @@ Description:
 Returns:
  <literal>0</literal> on success, <literal>-1</literal> on error.
 
+Function: comedi_get_cmd_timing_constraints -- Get the hardware timing constraints for a streaming subdevice
+Retval: int
+Param: comedi_t * device
+Param: unsigned int subdevice
+Param: unsigned int scan_begin_src
+Param: unsigned int * scan_begin_min
+Param: unsigned int convert_src
+Param: unsigned int * convert_min
+Param: unsigned int * chanlist
+Param: unsigned int chanlist_len
+Status: alpha
+Description:
+ This function queries the hardware timing constraints of a streaming subdevice.
+
+ The values returned by this function may indicate the range of valid inputs
+ for
+ <code language="C">comedi_cmd->scan_begin_arg</code> and
+ <code language="C">comedi_cmd->convert_arg</code>, for instance when
+ <code language="C">comedi_cmd->scan_begin_src==TRIG_TIMER</code> or
+ <code language="C">comedi_cmd->convert_src==TRIG_TIMER</code>.  For
+ <code language="C">TRIG_EXT</code> (or other modes?), these returned values are
+ mostly informational and may be used in conjunction with other triggering
+ hardware.
+
+ If it is possible for the hardware constraints to depend on whether
+ <code language="C">[*]_src==TRIG_TIMER</code> or
+ <code language="C">[*]_src==TRIG_EXT</code>, the values returned by this
+ function will depend on these inputs.  Alternatively, one can specify something
+ like <code language="C">[*]_src==TRIG_TIMER|TRIG_EXT</code> and retrieve the
+ value that is the smallest that satisfies both trigger sources.
+
+ <parameter class="function">scan_begin_min</parameter> may be given as
+ <code language="C">NULL</code>, such that nothing will be returned for minimum
+ scan speed.
+
+ <parameter class="function">convert_min</parameter> may be given as
+ <code language="C">NULL</code>, such that nothing will be returned for minimum
+ scan speed.
+
+Returns:
+ <literal>0</literal> on success, <literal>-1</literal> on error.
+
 Function: comedi_get_gate_source -- get gate for a subdevice
 Retval: int
 Param: comedi_t * device

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -308,6 +308,8 @@ typedef struct comedi_insn_struct     <link linkend="ref-type-comedi-insn">comed
 typedef struct comedi_range_struct    <link linkend="ref-type-comedi-range">comedi_range</link>;
 typedef struct comedi_krange_struct   <link linkend="ref-type-comedi-krange">comedi_krange</link>;
 typedef struct comedi_insnlist_struct <link linkend="ref-type-comedi-insnlist">comedi_insnlist</link>;
+typedef                               <link linkend="ref-type-comedi-polynomial-t">comedi_polynomial_t</link>;
+typedef                               <link linkend="ref-type-comedi-route-pair">comedi_route_pair</link>;
 </programlisting>
 The data structures used in the implementation of the &comedi; drivers
 are described in <xref linkend="driverdatastructures"/>.
@@ -743,6 +745,33 @@ calibration functions and is passed to the
 <function><link linkend="func-ref-comedi-to-physical">comedi_to_physical</link></function>
 and <function><link linkend="func-ref-comedi-from-physical">comedi_from_physical</link></function>
 raw/physical conversion functions.
+</para>
+
+</section>
+
+<section id="ref-type-comedi-route-pair">
+<title>
+comedi_route_pair
+</title>
+
+<programlisting>
+typedef struct {
+  unsigned int source;
+  unsigned int destination;
+} comedi_route_pair;
+</programlisting>
+
+<para>
+An array of <type>comedi_route_pair</type> objects is used to gain a list of
+routes that are valid for a particular device via
+<function><link linkend="func-ref-comedi-get-routes">comedi_get_routes</link></function>.
+The values for <parameter>source</parameter> and
+<parameter>destination</parameter> are globally identifiable for the entire
+device as used by
+<function><link linkend="func-ref-comedi-test-route">comedi_test_route</link></function>,
+<function><link linkend="func-ref-comedi-connect-route">comedi_connect_route</link></function>,
+and
+<function><link linkend="func-ref-comedi-disconnect-route">comedi_disconnect_route</link></function>.
 </para>
 
 </section>

--- a/include/comedi.h
+++ b/include/comedi.h
@@ -325,6 +325,8 @@ enum comedi_io_direction {
  * @INSN_CONFIG_PWM_SET_H_BRIDGE: Set PWM H bridge duty cycle and polarity for
  *				a relay simultaneously.
  * @INSN_CONFIG_PWM_GET_H_BRIDGE: Get PWM H bridge duty cycle and polarity.
+ * @INSN_CONFIG_GET_CMD_TIMING_CONSTRAINTS: Get the hardware timing restraints,
+ *				regardless of trigger sources.
  */
 enum configuration_ids {
 	INSN_CONFIG_DIO_INPUT = COMEDI_INPUT,
@@ -368,7 +370,8 @@ enum configuration_ids {
 	INSN_CONFIG_PWM_GET_PERIOD = 5001,
 	INSN_CONFIG_GET_PWM_STATUS = 5002,
 	INSN_CONFIG_PWM_SET_H_BRIDGE = 5003,
-	INSN_CONFIG_PWM_GET_H_BRIDGE = 5004
+	INSN_CONFIG_PWM_GET_H_BRIDGE = 5004,
+	INSN_CONFIG_GET_CMD_TIMING_CONSTRAINTS = 5005,
 };
 
 /**

--- a/include/comedi.h
+++ b/include/comedi.h
@@ -130,6 +130,7 @@ typedef unsigned short sampl_t;
 #define INSN_WRITE		(1 | INSN_MASK_WRITE)
 #define INSN_BITS		(2 | INSN_MASK_READ | INSN_MASK_WRITE)
 #define INSN_CONFIG		(3 | INSN_MASK_READ | INSN_MASK_WRITE)
+#define INSN_DEVICE_CONFIG	(INSN_CONFIG | INSN_MASK_SPECIAL)
 #define INSN_GTOD		(4 | INSN_MASK_READ | INSN_MASK_SPECIAL)
 #define INSN_WAIT		(5 | INSN_MASK_WRITE | INSN_MASK_SPECIAL)
 #define INSN_INTTRIG		(6 | INSN_MASK_WRITE | INSN_MASK_SPECIAL)
@@ -318,11 +319,6 @@ enum comedi_io_direction {
  * @INSN_CONFIG_8254_READ_STATUS: Read status of 8254 counter channel.
  * @INSN_CONFIG_SET_ROUTING:	Set routing for a channel.
  * @INSN_CONFIG_GET_ROUTING:	Get routing for a channel.
- * @INSN_CONFIG_TEST_ROUTE:	Validate the possibility of a globally-named route
- * @INSN_CONFIG_CONNECT_ROUTE:	Connect a globally-named route
- * @INSN_CONFIG_DISCONNECT_ROUTE:Disconnect a globally-named route
- * @INSN_CONFIG_GET_ROUTES:	Get a list of all globally-named routes that are
- *				valid for a particular device.
  * @INSN_CONFIG_PWM_SET_PERIOD: Set PWM period in nanoseconds.
  * @INSN_CONFIG_PWM_GET_PERIOD: Get PWM period in nanoseconds.
  * @INSN_CONFIG_GET_PWM_STATUS: Get PWM status.
@@ -373,6 +369,23 @@ enum configuration_ids {
 	INSN_CONFIG_GET_PWM_STATUS = 5002,
 	INSN_CONFIG_PWM_SET_H_BRIDGE = 5003,
 	INSN_CONFIG_PWM_GET_H_BRIDGE = 5004
+};
+
+/**
+ * enum device_configuration_ids - COMEDI configuration instruction codes global
+ * to an entire device.
+ * @INSN_DEVICE_CONFIG_TEST_ROUTE:	Validate the possibility of a
+ *					globally-named route
+ * @INSN_DEVICE_CONFIG_CONNECT_ROUTE:	Connect a globally-named route
+ * @INSN_DEVICE_CONFIG_DISCONNECT_ROUTE:Disconnect a globally-named route
+ * @INSN_DEVICE_CONFIG_GET_ROUTES:	Get a list of all globally-named routes
+ *					that are valid for a particular device.
+ */
+enum device_config_route_ids {
+	INSN_DEVICE_CONFIG_TEST_ROUTE = 0,
+	INSN_DEVICE_CONFIG_CONNECT_ROUTE = 1,
+	INSN_DEVICE_CONFIG_DISCONNECT_ROUTE = 2,
+	INSN_DEVICE_CONFIG_GET_ROUTES = 3,
 };
 
 /**
@@ -967,6 +980,157 @@ enum i8254_mode {
 	I8254_BCD = 1,
 	I8254_BINARY = 0
 };
+
+/* *** BEGIN GLOBALLY-NAMED NI TERMINALS/SIGNALS *** */
+
+/*
+ * Common National Instruments Terminal/Signal names.
+ * Some of these have no NI_ prefix as they are useful for non-NI hardware, such
+ * as those that utilize the PXI/RTSI trigger lines.
+ *
+ * NOTE ABOUT THE CHOICE OF NAMES HERE AND THE CAMELSCRIPT:
+ *   The choice to use CamelScript and the exact names below is for
+ *   maintainability, clarity, similarity to manufacturer's documentation,
+ *   _and_ a mitigation for confusion that has plagued the use of these drivers
+ *   for years!
+ *
+ *   More detail:
+ *   There have been significant confusions over the past many years for users
+ *   when trying to understand how to connect to/from signals and terminals on
+ *   NI hardware using comedi.  The major reason for this is that the actual
+ *   register values were exposed and required to be used by users.  Several
+ *   major reasons exist why this caused major confusion for users:
+ *   1) The register values are _NOT_ in user documentation, but rather in
+ *     arcane locations, such as a few register programming manuals that are
+ *     increasingly hard to find and the NI MHDDK (comments in in example code).
+ *     There is no one place to find the various valid values of the registers.
+ *   2) The register values are _NOT_ completely consistent.  There is no way to
+ *     gain any sense of intuition of which values, or even enums one should use
+ *     for various registers.  There was some attempt in prior use of comedi to
+ *     name enums such that a user might know which enums should be used for
+ *     varying purposes, but the end-user had to gain a knowledge of register
+ *     values to correctly wield this approach.
+ *   3) The names for signals and registers found in the various register level
+ *     programming manuals and vendor-provided documentation are _not_ even
+ *     close to the same names that are in the end-user documentation.
+ *
+ *   Similar, albeit less, confusion plagued NI's previous version of their own
+ *   drivers.  Earlier than 2003, NI greatly simplified the situation for users
+ *   by releasing a new API that abstracted the names of signals/terminals to a
+ *   common and intuitive set of names.
+ *
+ *   The names below mirror the names chosen and well documented by NI.  These
+ *   names are exposed to the user via the comedilib user library.  By keeping
+ *   the names below, in spite of the use of CamelScript, maintenance will be
+ *   greatly eased and confusion for users _and_ comedi developers will be
+ *   greatly reduced.
+ */
+
+/*
+ * Base of abstracted NI names.
+ * The first 16 bits of *_arg are reserved for channel selection.
+ * Since we only actually need the first 4 or 5 bits for all register values on
+ * NI select registers anyways, we'll identify all values >= (1<<15) as being an
+ * abstracted NI signal/terminal name.
+ * These values are also used/returned by INSN_DEVICE_CONFIG_TEST_ROUTE,
+ * INSN_DEVICE_CONFIG_CONNECT_ROUTE, INSN_DEVICE_CONFIG_DISCONNECT_ROUTE,
+ * and INSN_DEVICE_CONFIG_GET_ROUTES.
+ */
+#define NI_NAMES_BASE	0x8000u
+/*
+ * not necessarily all allowed 64 PFIs are valid--certainly not for all devices
+ */
+#define NI_PFI(x)	(NI_NAMES_BASE        + ((x) & 0x3f))
+/* 8 trigger lines by standard, Some devices cannot talk to all eight. */
+#define TRIGGER_LINE(x)	(NI_PFI(-1)       + 1 + ((x) & 0x7))
+/* 4 RTSI shared MUXes to route signals to/from TRIGGER_LINES on NI hardware */
+#define NI_RTSI_BRD(x)	(TRIGGER_LINE(-1) + 1 + ((x) & 0x3))
+
+/* *** Counter/timer names : 8 counters max *** */
+#define NI_COUNTER_NAMES_BASE  (NI_RTSI_BRD(-1)  + 1)
+#define NI_MAX_COUNTERS	       7
+#define NI_CtrSource(x)	       (NI_COUNTER_NAMES_BASE + ((x) & NI_MAX_COUNTERS))
+/* Gate, Aux, A,B,Z are all treated, at times as gates */
+#define NI_GATES_NAMES_BASE    (NI_CtrSource(-1) + 1)
+#define NI_CtrGate(x)	       (NI_GATES_NAMES_BASE   + ((x) & NI_MAX_COUNTERS))
+#define NI_CtrAux(x)	       (NI_CtrGate(-1)   + 1  + ((x) & NI_MAX_COUNTERS))
+#define NI_CtrA(x)	       (NI_CtrAux(-1)    + 1  + ((x) & NI_MAX_COUNTERS))
+#define NI_CtrB(x)	       (NI_CtrA(-1)      + 1  + ((x) & NI_MAX_COUNTERS))
+#define NI_CtrZ(x)	       (NI_CtrB(-1)      + 1  + ((x) & NI_MAX_COUNTERS))
+#define NI_GATES_NAMES_MAX     NI_CtrZ(-1)
+#define NI_CtrArmStartTrigger(x) (NI_CtrZ(-1)    + 1  + ((x) & NI_MAX_COUNTERS))
+#define NI_CtrInternalOutput(x) \
+		     (NI_CtrArmStartTrigger(-1)  + 1  + ((x) & NI_MAX_COUNTERS))
+/** external pin(s) labeled conveniently as Ctr<i>Out. */
+#define NI_CtrOut(x)  (NI_CtrInternalOutput(-1)  + 1  + ((x) & NI_MAX_COUNTERS))
+/** For Buffered sampling of ctr -- x series capability. */
+#define NI_CtrSampleClock(x)	(NI_CtrOut(-1)   + 1  + ((x) & NI_MAX_COUNTERS))
+#define NI_COUNTER_NAMES_MAX   NI_CtrSampleClock(-1)
+
+enum ni_common_signal_names {
+	/* PXI_Star: this is a non-NI-specific signal */
+	PXI_Star = NI_COUNTER_NAMES_MAX + 1,
+	PXI_Clk10,
+	PXIe_Clk100,
+	NI_AI_SampleClock,
+	NI_AI_SampleClockTimebase,
+	NI_AI_StartTrigger,
+	NI_AI_ReferenceTrigger,
+	NI_AI_ConvertClock,
+	NI_AI_ConvertClockTimebase,
+	NI_AI_PauseTrigger,
+	NI_AI_HoldCompleteEvent,
+	NI_AI_HoldComplete,
+	NI_AI_ExternalMUXClock,
+	NI_AI_STOP, /* pulse signal that occurs when a update is finished(?) */
+	NI_AO_SampleClock,
+	NI_AO_SampleClockTimebase,
+	NI_AO_StartTrigger,
+	NI_AO_PauseTrigger,
+	NI_DI_SampleClock,
+	NI_DI_SampleClockTimebase,
+	NI_DI_StartTrigger,
+	NI_DI_ReferenceTrigger,
+	NI_DI_PauseTrigger,
+	NI_DI_InputBufferFull,
+	NI_DI_ReadyForStartEvent,
+	NI_DI_ReadyForTransferEventBurst,
+	NI_DI_ReadyForTransferEventPipelined,
+	NI_DO_SampleClock,
+	NI_DO_SampleClockTimebase,
+	NI_DO_StartTrigger,
+	NI_DO_PauseTrigger,
+	NI_DO_OutputBufferFull,
+	NI_DO_DataActiveEvent,
+	NI_DO_ReadyForStartEvent,
+	NI_DO_ReadyForTransferEvent,
+	NI_MasterTimebase,
+	NI_20MHzTimebase,
+	NI_80MHzTimebase,
+	NI_100MHzTimebase,
+	NI_200MHzTimebase,
+	NI_100kHzTimebase,
+	NI_10MHzRefClock,
+	NI_FrequencyOutput,
+	NI_ChangeDetectionEvent,
+	NI_AnalogComparisonEvent,
+	NI_WatchdogExpiredEvent,
+	NI_WatchdogExpirationTrigger,
+	NI_SCXI_Trig1,
+	NI_LogicLow,
+	NI_LogicHigh,
+	NI_ExternalStrobe,
+	NI_PFI_DO,
+	NI_CaseGround,
+	/* special internal signal used as variable source for RTSI bus: */
+	NI_RGOUT0,
+
+	/* just a name to make the next more convenient, regardless of above */
+	_NI_NAMES_MAX_PLUS_1,
+	NI_NUM_NAMES = _NI_NAMES_MAX_PLUS_1 - NI_NAMES_BASE,
+};
+
+/* *** END GLOBALLY-NAMED NI TERMINALS/SIGNALS *** */
 
 #define NI_USUAL_PFI_SELECT(x)	(((x) < 10) ? (0x1 + (x)) : (0xb + (x)))
 #define NI_USUAL_RTSI_SELECT(x)	(((x) < 7) ? (0xb + (x)) : 0x1b)

--- a/include/comedi.h
+++ b/include/comedi.h
@@ -1040,35 +1040,38 @@ enum i8254_mode {
  * and INSN_DEVICE_CONFIG_GET_ROUTES.
  */
 #define NI_NAMES_BASE	0x8000u
+
+#define _TERM_N(base, n, x)	((base) + ((x) & ((n) - 1)))
+
 /*
  * not necessarily all allowed 64 PFIs are valid--certainly not for all devices
  */
-#define NI_PFI(x)	(NI_NAMES_BASE        + ((x) & 0x3f))
+#define NI_PFI(x)		_TERM_N(NI_NAMES_BASE, 64, x)
 /* 8 trigger lines by standard, Some devices cannot talk to all eight. */
-#define TRIGGER_LINE(x)	(NI_PFI(-1)       + 1 + ((x) & 0x7))
+#define TRIGGER_LINE(x)		_TERM_N(NI_PFI(-1) + 1, 8, x)
 /* 4 RTSI shared MUXes to route signals to/from TRIGGER_LINES on NI hardware */
-#define NI_RTSI_BRD(x)	(TRIGGER_LINE(-1) + 1 + ((x) & 0x3))
+#define NI_RTSI_BRD(x)		_TERM_N(TRIGGER_LINE(-1) + 1, 4, x)
 
 /* *** Counter/timer names : 8 counters max *** */
-#define NI_COUNTER_NAMES_BASE  (NI_RTSI_BRD(-1)  + 1)
-#define NI_MAX_COUNTERS	       7
-#define NI_CtrSource(x)	       (NI_COUNTER_NAMES_BASE + ((x) & NI_MAX_COUNTERS))
+#define NI_MAX_COUNTERS		8
+#define NI_COUNTER_NAMES_BASE	(NI_RTSI_BRD(-1)  + 1)
+#define NI_CtrSource(x)	      _TERM_N(NI_COUNTER_NAMES_BASE, NI_MAX_COUNTERS, x)
 /* Gate, Aux, A,B,Z are all treated, at times as gates */
-#define NI_GATES_NAMES_BASE    (NI_CtrSource(-1) + 1)
-#define NI_CtrGate(x)	       (NI_GATES_NAMES_BASE   + ((x) & NI_MAX_COUNTERS))
-#define NI_CtrAux(x)	       (NI_CtrGate(-1)   + 1  + ((x) & NI_MAX_COUNTERS))
-#define NI_CtrA(x)	       (NI_CtrAux(-1)    + 1  + ((x) & NI_MAX_COUNTERS))
-#define NI_CtrB(x)	       (NI_CtrA(-1)      + 1  + ((x) & NI_MAX_COUNTERS))
-#define NI_CtrZ(x)	       (NI_CtrB(-1)      + 1  + ((x) & NI_MAX_COUNTERS))
-#define NI_GATES_NAMES_MAX     NI_CtrZ(-1)
-#define NI_CtrArmStartTrigger(x) (NI_CtrZ(-1)    + 1  + ((x) & NI_MAX_COUNTERS))
+#define NI_GATES_NAMES_BASE	(NI_CtrSource(-1) + 1)
+#define NI_CtrGate(x)		_TERM_N(NI_GATES_NAMES_BASE, NI_MAX_COUNTERS, x)
+#define NI_CtrAux(x)		_TERM_N(NI_CtrGate(-1)  + 1, NI_MAX_COUNTERS, x)
+#define NI_CtrA(x)		_TERM_N(NI_CtrAux(-1)   + 1, NI_MAX_COUNTERS, x)
+#define NI_CtrB(x)		_TERM_N(NI_CtrA(-1)     + 1, NI_MAX_COUNTERS, x)
+#define NI_CtrZ(x)		_TERM_N(NI_CtrB(-1)     + 1, NI_MAX_COUNTERS, x)
+#define NI_GATES_NAMES_MAX	NI_CtrZ(-1)
+#define NI_CtrArmStartTrigger(x) _TERM_N(NI_CtrZ(-1)    + 1, NI_MAX_COUNTERS, x)
 #define NI_CtrInternalOutput(x) \
-		     (NI_CtrArmStartTrigger(-1)  + 1  + ((x) & NI_MAX_COUNTERS))
+		      _TERM_N(NI_CtrArmStartTrigger(-1) + 1, NI_MAX_COUNTERS, x)
 /** external pin(s) labeled conveniently as Ctr<i>Out. */
-#define NI_CtrOut(x)  (NI_CtrInternalOutput(-1)  + 1  + ((x) & NI_MAX_COUNTERS))
+#define NI_CtrOut(x)   _TERM_N(NI_CtrInternalOutput(-1) + 1, NI_MAX_COUNTERS, x)
 /** For Buffered sampling of ctr -- x series capability. */
-#define NI_CtrSampleClock(x)	(NI_CtrOut(-1)   + 1  + ((x) & NI_MAX_COUNTERS))
-#define NI_COUNTER_NAMES_MAX   NI_CtrSampleClock(-1)
+#define NI_CtrSampleClock(x)	_TERM_N(NI_CtrOut(-1)   + 1, NI_MAX_COUNTERS, x)
+#define NI_COUNTER_NAMES_MAX	NI_CtrSampleClock(-1)
 
 enum ni_common_signal_names {
 	/* PXI_Star: this is a non-NI-specific signal */

--- a/include/comedi.h
+++ b/include/comedi.h
@@ -698,7 +698,7 @@ struct comedi_rangeinfo_struct {
  * by 1e6, so a @max value of %1000000 (with %UNIT_volt) represents a maximal
  * value of 1 volt.
  *
- * The only defined flag value is %RF_external (%1 << %8), indicating that the
+ * The only defined flag value is %RF_EXTERNAL (%0x100), indicating that the
  * the range needs to be multiplied by an external reference.
  */
 struct comedi_krange_struct {
@@ -1134,12 +1134,15 @@ enum ni_gpct_other_select {
  */
 enum ni_gpct_arm_source {
 	NI_GPCT_ARM_IMMEDIATE = 0x0,
-	/* Start both the counter and the adjacent paired counter simultaneously */
+	/*
+	 * Start both the counter and the adjacent paired counter simultaneously
+	 */
 	NI_GPCT_ARM_PAIRED_IMMEDIATE = 0x1,
 	/*
-	 * If the NI_GPCT_HW_ARM bit is set, we will pass the least significant bits
-	 * (3 bits for 660x or 5 bits for m-series) through to the hardware. To select
-	 * a hardware trigger, pass the appropriate select bit, e.g.,
+	 * If the NI_GPCT_HW_ARM bit is set, we will pass the least significant
+	 * bits (3 bits for 660x or 5 bits for m-series) through to the
+	 * hardware. To select a hardware trigger, pass the appropriate select
+	 * bit, e.g.,
 	 * NI_GPCT_HW_ARM | NI_GPCT_AI_START1_GATE_SELECT or
 	 * NI_GPCT_HW_ARM | NI_GPCT_PFI_GATE_SELECT(pfi_number)
 	 */

--- a/include/comedi.h
+++ b/include/comedi.h
@@ -259,6 +259,22 @@ enum comedi_subdevice_type {
 /* configuration instructions */
 
 /**
+ * enum comedi_io_direction - COMEDI I/O directions
+ * @COMEDI_INPUT:	Input.
+ * @COMEDI_OUTPUT:	Output.
+ * @COMEDI_OPENDRAIN:	Open-drain (or open-collector) output.
+ *
+ * These are used by the %INSN_CONFIG_DIO_QUERY configuration instruction to
+ * report a direction.  They may also be used in other places where a direction
+ * needs to be specified.
+ */
+enum comedi_io_direction {
+	COMEDI_INPUT = 0,
+	COMEDI_OUTPUT = 1,
+	COMEDI_OPENDRAIN = 2
+};
+
+/**
  * enum configuration_ids - COMEDI configuration instruction codes
  * @INSN_CONFIG_DIO_INPUT:	Configure digital I/O as input.
  * @INSN_CONFIG_DIO_OUTPUT:	Configure digital I/O as output.
@@ -315,9 +331,9 @@ enum comedi_subdevice_type {
  * @INSN_CONFIG_PWM_GET_H_BRIDGE: Get PWM H bridge duty cycle and polarity.
  */
 enum configuration_ids {
-	INSN_CONFIG_DIO_INPUT = 0,
-	INSN_CONFIG_DIO_OUTPUT = 1,
-	INSN_CONFIG_DIO_OPENDRAIN = 2,
+	INSN_CONFIG_DIO_INPUT = COMEDI_INPUT,
+	INSN_CONFIG_DIO_OUTPUT = COMEDI_OUTPUT,
+	INSN_CONFIG_DIO_OPENDRAIN = COMEDI_OPENDRAIN,
 	INSN_CONFIG_ANALOG_TRIG = 16,
 /*	INSN_CONFIG_WAVEFORM = 17, */
 /*	INSN_CONFIG_TRIG = 18, */
@@ -413,22 +429,6 @@ enum comedi_digital_trig_op {
 	COMEDI_DIGITAL_TRIG_DISABLE = 0,
 	COMEDI_DIGITAL_TRIG_ENABLE_EDGES = 1,
 	COMEDI_DIGITAL_TRIG_ENABLE_LEVELS = 2
-};
-
-/**
- * enum comedi_io_direction - COMEDI I/O directions
- * @COMEDI_INPUT:	Input.
- * @COMEDI_OUTPUT:	Output.
- * @COMEDI_OPENDRAIN:	Open-drain (or open-collector) output.
- *
- * These are used by the %INSN_CONFIG_DIO_QUERY configuration instruction to
- * report a direction.  They may also be used in other places where a direction
- * needs to be specified.
- */
-enum comedi_io_direction {
-	COMEDI_INPUT = 0,
-	COMEDI_OUTPUT = 1,
-	COMEDI_OPENDRAIN = 2
 };
 
 /**

--- a/include/comedilib.h
+++ b/include/comedilib.h
@@ -1,3 +1,4 @@
+/* vim: set ts=8 sw=8 noet tw=80 nowrap: */
 /*
     include/comedilib.h
     header file for the comedi library routines
@@ -332,6 +333,48 @@ int comedi_digital_trigger_enable_edges(comedi_t *device, unsigned subdevice,
 int comedi_digital_trigger_enable_levels(comedi_t *device, unsigned subdevice,
 	unsigned trigger_id, unsigned base_input,
 	unsigned high_level_inputs, unsigned low_level_inputs);
+
+/**
+ * Get the hardware timing constraints for a streaming subdevice.
+ *
+ * The values returned by this function may indicate the range of valid inputs
+ * for scan_begin_arg and convert_arg, for instance when *_src==TRIG_TIMER.  For
+ * *_src==TRIG_EXT (or other modes?), these returned values are mostly
+ * informational and may be used in conjunction with other triggering hardware.
+ *
+ * If it is possible for the hardware constraints to depend on whether
+ * *_src==TRIG_TIMER or *_src==TRIG_EXT, the values returned by this function
+ * will depend on these inputs.  Alternatively, one can specify something like
+ * *_src==TRIG_TIMER|TRIG_EXT and retrieve the value that is the smallest that
+ * satisfies both trigger sources.
+ *
+ * @param device
+ *	Pointer to the device
+ * @param subdevice
+ *	Index of the streaming/async subdevice to query
+ * @param scan_begin_src
+ *	Bitwise or of all trigger modes (TRIG_INT, TRIG_EXT, ...) that should be
+ *	considered.
+ * @param scan_begin_min
+ *	If not NULL, this pointer is to return the value of minimum scan_begin
+ *	speed that meets the requirements of the slowest trigger specified in
+ *	scan_begin_src.
+ * @param convert_src
+ *	Bitwise or of all trigger modes (TRIG_INT, TRIG_EXT, ...) that should be
+ *	considered.
+ * @param convert_min
+ *	If not NULL, this pointer is to return the value of minimum convert
+ *	speed that meets the requirements of the slowest trigger specified in
+ *	convert_src.
+ * @return 0 if successful or -1 otherwise
+ */
+int comedi_get_cmd_timing_constraints(comedi_t *device, unsigned int subdevice,
+				      unsigned int scan_begin_src,
+				      unsigned int *scan_begin_min,
+				      unsigned int convert_src,
+				      unsigned int *convert_min,
+				      unsigned int *chanlist,
+				      unsigned int chanlist_len);
 
 /**
  * Validate a globally-named route as connectible and test whether it is

--- a/lib/insn_config_wrappers.c
+++ b/lib/insn_config_wrappers.c
@@ -1,3 +1,4 @@
+/* vim: set ts=8 sw=8 noet tw=80 nowrap: */
 /*
     lib/insn_config_wrappers.c
     wrappers for various INSN_CONFIG instructions
@@ -23,6 +24,7 @@
 */
 
 #include <string.h>
+#include <stdlib.h>
 
 #include "libinternal.h"
 
@@ -457,6 +459,45 @@ int _comedi_get_routes(comedi_t *device, comedi_route_pair * routelist, size_t n
 			routelist[i].source	 = insn.data[2 + 2*i];
 			routelist[i].destination = insn.data[2 + 2*i + 1];
 		}
+	}
+
+	free(insn.data);
+	return retval;
+}
+
+EXPORT_ALIAS_DEFAULT(_comedi_get_cmd_timing_constraints,comedi_get_cmd_timing_constraints,0.12.0);
+int _comedi_get_cmd_timing_constraints(comedi_t *device, unsigned int subdevice,
+				       unsigned int scan_begin_src,
+				       unsigned int *scan_begin_min,
+				       unsigned int convert_src,
+				       unsigned int *convert_min,
+				       unsigned int *chanlist,
+				       unsigned int chanlist_len)
+{
+	comedi_insn insn;
+	size_t i;
+	int retval = -1;
+
+	memset(&insn, 0, sizeof(comedi_insn));
+	insn.insn   = INSN_CONFIG;
+	insn.n	    = 4 + chanlist_len;
+	insn.subdev = subdevice;
+	insn.data   = calloc(sizeof(lsampl_t), insn.n);
+	insn.data[0]= INSN_CONFIG_GET_CMD_TIMING_CONSTRAINTS;
+	insn.data[1]= scan_begin_src; // scan_begin_min on return
+	insn.data[2]= convert_src;    // convert_min on return
+	insn.data[3]= chanlist_len;
+
+	for (i = 0; i < chanlist_len; ++i) {
+		insn.data[4+i] = chanlist[i];
+	}
+
+	if(comedi_do_insn(device, &insn) >= 0) {
+		if (scan_begin_min)
+			*scan_begin_min = insn.data[1];
+		if (convert_min)
+			*convert_min    = insn.data[2];
+		retval = 0;
 	}
 
 	free(insn.data);

--- a/lib/version_script
+++ b/lib/version_script
@@ -133,3 +133,12 @@ v0.11.0 {
 		comedi_get_buffer_read_count;
 		comedi_get_buffer_write_count;
 } v0.10.0;
+
+v0.12.0 {
+	global:
+		comedi_test_route;
+		comedi_connect_route;
+		comedi_disconnect_route;
+		comedi_get_routes;
+		comedi_get_cmd_timing_constraints;
+} v0.11.0;

--- a/swig/comedi.i
+++ b/swig/comedi.i
@@ -98,6 +98,18 @@ unsigned int NI_CDIO_SCAN_BEGIN_SRC_PFI(unsigned int pfi_channel);
 unsigned int NI_CDIO_SCAN_BEGIN_SRC_RTSI(unsigned int rtsi_channel);
 unsigned int NI_AO_SCAN_BEGIN_SRC_PFI(unsigned int pfi_channel);
 unsigned int NI_AO_SCAN_BEGIN_SRC_RTSI(unsigned int rtsi_channel);
+unsigned int NI_PFI(int channel);
+unsigned int TRIGGER_LINE(int channel);
+unsigned int NI_RTSI_BRD(int channel);
+unsigned int NI_CtrSource(int channel);
+unsigned int NI_CtrGate(int channel);
+unsigned int NI_CtrAux(int channel);
+unsigned int NI_CtrA(int channel);
+unsigned int NI_CtrB(int channel);
+unsigned int NI_CtrZ(int channel);
+unsigned int NI_CtrArmStartTrigger(int channel);
+unsigned int NI_CtrInternalOutput(int channel);
+unsigned int NI_CtrOut(int channel);
 
 #ifdef SWIGRUBY
 %typemap(argout) comedi_cmd *INOUT(VALUE info) {


### PR DESCRIPTION
These patches implement the user code that interacts with the new device-global routing capability that was recently accepted into the kernel.  This does change the version to 0.12.0, because of the interface addition and following the versioning rules indicated in configure.ac.